### PR TITLE
Fix some python warnings

### DIFF
--- a/pox/config/__init__.py
+++ b/pox/config/__init__.py
@@ -165,7 +165,8 @@ def launch (file, __INSTANCE__=None):
   lineno = 0
   ifstack = IfStack()
   try:
-    for line in open(file, "r"):
+    fp = open(file, "r")
+    for line in fp:
       lineno += 1
       line = line.lstrip().replace("\r","\n").rstrip("\n")
       if line.startswith("#"): continue
@@ -284,6 +285,8 @@ def launch (file, __INSTANCE__=None):
     l.exception("On line %s of config file '%s'" % (lineno,file))
     os._exit(1)
     #print "Error on line %s of config file '%s'." % (lineno,file)
+  finally:
+    fp.close()
 
   variables.clear()
 

--- a/pox/core.py
+++ b/pox/core.py
@@ -351,7 +351,7 @@ class POXCore (EventMixin):
     log.info("Down.")
     #logging.shutdown()
     self.quit_condition.acquire()
-    self.quit_condition.notifyAll()
+    self.quit_condition.notify_all()
     core.quit_condition.release()
 
   def _get_python_version (self):


### PR DESCRIPTION
Fixes some warnings found when running with `-X dev` on Python 3.10